### PR TITLE
Add test on GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,30 @@
+name: "Test"
+on:
+  pull_request:
+  push:
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: cachix/install-nix-action@v17
+      with:
+        nix_path: nixpkgs=channel:nixos-unstable
+
+    # - uses: cachix/cachix-action@v11
+    #   with:
+    #     name: mycache
+    #     # If you chose signing key for write access
+    #     signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
+    #     # If you chose API tokens for write access OR if you have a private cache
+    #     authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+
+    # - run: nix-build
+    - run: nix-shell --run "echo OK"
+      env: 
+        NIXPKGS_ALLOW_UNFREE: 1
+
+    - run: nix-shell --run "flutter build apk"
+      env: 
+        NIXPKGS_ALLOW_UNFREE: 1
+


### PR DESCRIPTION
Following the [NixOS guide on Continuous Integration with GitHub Actions](https://nixos.org/guides/continuous-integration-github-actions.html), this builds the APK on GitHub Actions.